### PR TITLE
fix: enlarge map on beamer page to minimal size

### DIFF
--- a/2013/fullscreen.php
+++ b/2013/fullscreen.php
@@ -293,7 +293,8 @@ var team<?= $deelgebied->getId() ?>_old = {
             		src="<?=BASE_URL?>fullscreen_map.php?team=<?= $deelgebied->getName() ?>"
             		id="iframe_<?= $deelgebied->getId() ?>"
             		width="100%"
-            		height="100%">
+            		height="100%"
+			style="min-height: 300px;">
             	</iframe>
             	<?php } ?>
             </td>


### PR DESCRIPTION
De kaarten zien er op dit moment uit als rechthoeken, deze commit vult het gehele vakje.

Oud: 
![image](https://user-images.githubusercontent.com/3273394/195629430-e806ff79-39ef-4881-9a8f-325153a62bdc.png)

Nieuw:

![image](https://user-images.githubusercontent.com/3273394/195629642-7452b5ec-dc50-4ada-9a4e-6854372babdc.png)
